### PR TITLE
Add events page

### DIFF
--- a/app/views/conferences_primer_theme/pages/events.html.haml
+++ b/app/views/conferences_primer_theme/pages/events.html.haml
@@ -1,4 +1,6 @@
 - cache current_page do
+  %h1= current_page.title
+
   - cache partable_for(:text) do
     - if has_content? :text
       .mt-4= render partial: 'text', object: content(:text)

--- a/app/views/conferences_primer_theme/pages/events.html.haml
+++ b/app/views/conferences_primer_theme/pages/events.html.haml
@@ -1,0 +1,8 @@
+- cache current_page do
+  - cache partable_for(:text) do
+    - if has_content? :text
+      .mt-4= render partial: 'text', object: content(:text)
+  - cache [partable_for(:events_list), content(:events_list)&.structure_items, 
+           content(:events_list)&.structure_items&.collect_concat(&:structure_parts)&.collect(&:structure_partable)] do
+    - if has_content?(:events_list) && content(:events_list).structure_items.any?
+      .mt-2= render partial: 'events_list', object: content(:events_list)

--- a/app/views/conferences_primer_theme/pages/events.html.haml
+++ b/app/views/conferences_primer_theme/pages/events.html.haml
@@ -8,3 +8,5 @@
            content(:events_list)&.structure_items&.collect_concat(&:structure_parts)&.collect(&:structure_partable)] do
     - if has_content?(:events_list) && content(:events_list).structure_items.any?
       .mt-2= render partial: 'events_list', object: content(:events_list)
+    - else
+      = render Primer::BlankslateComponent.new(title: t(:'.no_events'), icon: 'calendar')

--- a/app/views/spina/pages/_event.html.haml
+++ b/app/views/spina/pages/_event.html.haml
@@ -1,0 +1,18 @@
+- cache [event, event.structure_parts.collect(&:structure_partable)] do
+  .d-flex.flex-column.flex-items-start
+    - cache partable_for(:name, parent: event) do
+      - if event.has_content?(:name)
+        %h3.flex-auto= event.content(:name)
+    - cache partable_for(:location, :start_time, parent: event) do
+      -# TODO: use 'format: :full' once edit-submission-flash is merged
+      %h4.flex-auto= t(:'.time_and_place', time: event.has_content?(:start_time) ? time_tag(event.content(:start_time), format: :short) : t('.time_tbc'),
+                                          place: event.has_content?(:location) ? event.content(:location) : t('.location_tbc')).try(:html_safe)
+    - cache partable_for(:description, parent: event) do
+      - if event.has_content?(:description)
+        .mt-1.text-gray-light= event.content(:description).try(:html_safe)
+    - cache partable_for(:url, parent: event) do
+      - if event.has_content?(:url)
+        .mt-2
+          = render Primer::ButtonComponent.new(tag: :a, href: event.content(:url)) do
+            = render Primer::OcticonComponent.new(icon: 'link-external')
+            = t :'.more_info'

--- a/app/views/spina/pages/_events_list.html.haml
+++ b/app/views/spina/pages/_events_list.html.haml
@@ -1,6 +1,16 @@
 - if events_list.structure_items.any?
-  %ul{ class: dom_class(events_list), id: dom_id(events_list) }
-    = render partial: 'event', collection: events_list.structure_items.sorted_by_structure, layout: 'list_item',
-             cached: ->(event) { [event, event.structure_parts.collect(&:structure_partable)] }
+  %div{ class: dom_class(events_list), id: dom_id(events_list) }
+    %h2= t :'.upcoming'
+    %ul
+      = render partial: 'event', 
+               collection: events_list.structure_items.sorted_by_structure.filter { |item| item.has_content?(:start_time) && item.content(:start_time) >= Time.now }, 
+               layout: 'list_item',
+               cached: ->(event) { [event, event.structure_parts.collect(&:structure_partable)] }
+    %h2.mt-4= t :'.past'
+    %ul
+      = render partial: 'event', 
+               collection: events_list.structure_items.sorted_by_structure.filter { |item| item.has_content?(:start_time) && item.content(:start_time) < Time.now }, 
+               layout: 'list_item',
+               cached: ->(event) { [event, event.structure_parts.collect(&:structure_partable)] }
 - else
   = render Primer::BlankSlateComponent.new(title: t(:'.no_events'), icon: 'file')

--- a/app/views/spina/pages/_events_list.html.haml
+++ b/app/views/spina/pages/_events_list.html.haml
@@ -2,17 +2,17 @@
   %div{ class: dom_class(events_list), id: dom_id(events_list) }
     = render Primer::SubheadComponent.new(mt: 4) do |component|
       = component.slot(:heading) { t :'.upcoming' }
+    - events_list.structure_items.sorted_by_structure.filter { |item| item.has_content?(:start_time) && item.content(:start_time) >= Time.now }.then do |events|
+      - if events.any?
         %ul
-      = render partial: 'event', 
-               collection: events_list.structure_items.sorted_by_structure.filter { |item| item.has_content?(:start_time) && item.content(:start_time) >= Time.now }, 
-               layout: 'list_item',
-               cached: ->(event) { [event, event.structure_parts.collect(&:structure_partable)] }
+          = render partial: 'event', layout: 'list_item', cached: ->(event) { [event, event.structure_parts.collect(&:structure_partable)] },
+                   collection: events
     = render Primer::SubheadComponent.new(mt: 4) do |component|
       = component.slot(:heading) { t :'.past' }
+    - events_list.structure_items.sorted_by_structure.filter { |item| item.has_content?(:start_time) && item.content(:start_time) < Time.now }.then do |events|
+      - if events.any?
         %ul
-      = render partial: 'event', 
-               collection: events_list.structure_items.sorted_by_structure.filter { |item| item.has_content?(:start_time) && item.content(:start_time) < Time.now }, 
-               layout: 'list_item',
-               cached: ->(event) { [event, event.structure_parts.collect(&:structure_partable)] }
+          = render partial: 'event', layout: 'list_item', cached: ->(event) { [event, event.structure_parts.collect(&:structure_partable)] },
+                   collection: events
       - else
   = render Primer::BlankSlateComponent.new(title: t(:'.no_events'), icon: 'file')

--- a/app/views/spina/pages/_events_list.html.haml
+++ b/app/views/spina/pages/_events_list.html.haml
@@ -7,6 +7,8 @@
         %ul
           = render partial: 'event', layout: 'list_item', cached: ->(event) { [event, event.structure_parts.collect(&:structure_partable)] },
                    collection: events
+      - else
+        = render Primer::BlankslateComponent.new(title: t(:'.no_events'), icon: 'calendar')
     = render Primer::SubheadComponent.new(mt: 4) do |component|
       = component.slot(:heading) { t :'.past' }
     - events_list.structure_items.sorted_by_structure.filter { |item| item.has_content?(:start_time) && item.content(:start_time) < Time.now }.then do |events|
@@ -15,4 +17,4 @@
           = render partial: 'event', layout: 'list_item', cached: ->(event) { [event, event.structure_parts.collect(&:structure_partable)] },
                    collection: events
       - else
-  = render Primer::BlankSlateComponent.new(title: t(:'.no_events'), icon: 'file')
+        = render Primer::BlankslateComponent.new(title: t(:'.no_events'), icon: 'calendar')

--- a/app/views/spina/pages/_events_list.html.haml
+++ b/app/views/spina/pages/_events_list.html.haml
@@ -1,16 +1,18 @@
 - if events_list.structure_items.any?
   %div{ class: dom_class(events_list), id: dom_id(events_list) }
-    %h2= t :'.upcoming'
-    %ul
+    = render Primer::SubheadComponent.new(mt: 4) do |component|
+      = component.slot(:heading) { t :'.upcoming' }
+        %ul
       = render partial: 'event', 
                collection: events_list.structure_items.sorted_by_structure.filter { |item| item.has_content?(:start_time) && item.content(:start_time) >= Time.now }, 
                layout: 'list_item',
                cached: ->(event) { [event, event.structure_parts.collect(&:structure_partable)] }
-    %h2.mt-4= t :'.past'
-    %ul
+    = render Primer::SubheadComponent.new(mt: 4) do |component|
+      = component.slot(:heading) { t :'.past' }
+        %ul
       = render partial: 'event', 
                collection: events_list.structure_items.sorted_by_structure.filter { |item| item.has_content?(:start_time) && item.content(:start_time) < Time.now }, 
                layout: 'list_item',
                cached: ->(event) { [event, event.structure_parts.collect(&:structure_partable)] }
-- else
+      - else
   = render Primer::BlankSlateComponent.new(title: t(:'.no_events'), icon: 'file')

--- a/app/views/spina/pages/_events_list.html.haml
+++ b/app/views/spina/pages/_events_list.html.haml
@@ -1,20 +1,19 @@
-- if events_list.structure_items.any?
-  %div{ class: dom_class(events_list), id: dom_id(events_list) }
-    = render Primer::SubheadComponent.new(mt: 4) do |component|
-      = component.slot(:heading) { t :'.upcoming' }
-    - events_list.structure_items.sorted_by_structure.filter { |item| item.has_content?(:start_time) && item.content(:start_time) >= Time.now }.then do |events|
-      - if events.any?
-        %ul
-          = render partial: 'event', layout: 'list_item', cached: ->(event) { [event, event.structure_parts.collect(&:structure_partable)] },
-                   collection: events
-      - else
-        = render Primer::BlankslateComponent.new(title: t(:'.no_events'), icon: 'calendar')
-    = render Primer::SubheadComponent.new(mt: 4) do |component|
-      = component.slot(:heading) { t :'.past' }
-    - events_list.structure_items.sorted_by_structure.filter { |item| item.has_content?(:start_time) && item.content(:start_time) < Time.now }.then do |events|
-      - if events.any?
-        %ul
-          = render partial: 'event', layout: 'list_item', cached: ->(event) { [event, event.structure_parts.collect(&:structure_partable)] },
-                   collection: events
-      - else
-        = render Primer::BlankslateComponent.new(title: t(:'.no_events'), icon: 'calendar')
+%div{ class: dom_class(events_list), id: dom_id(events_list) }
+  = render Primer::SubheadComponent.new(mt: 4) do |component|
+    = component.slot(:heading) { t :'.upcoming' }
+  - events_list.structure_items.sorted_by_structure.filter { |item| item.has_content?(:start_time) && item.content(:start_time) >= Time.now }.then do |events|
+    - if events.any?
+      %ul
+        = render partial: 'event', layout: 'list_item', cached: ->(event) { [event, event.structure_parts.collect(&:structure_partable)] },
+                 collection: events
+    - else
+      = render Primer::BlankslateComponent.new(title: t(:'.no_events'), icon: 'calendar')
+  = render Primer::SubheadComponent.new(mt: 4) do |component|
+    = component.slot(:heading) { t :'.past' }
+  - events_list.structure_items.sorted_by_structure.filter { |item| item.has_content?(:start_time) && item.content(:start_time) < Time.now }.then do |events|
+    - if events.any?
+      %ul
+        = render partial: 'event', layout: 'list_item', cached: ->(event) { [event, event.structure_parts.collect(&:structure_partable)] },
+                 collection: events
+    - else
+      = render Primer::BlankslateComponent.new(title: t(:'.no_events'), icon: 'calendar')

--- a/app/views/spina/pages/_events_list.html.haml
+++ b/app/views/spina/pages/_events_list.html.haml
@@ -1,0 +1,6 @@
+- if events_list.structure_items.any?
+  %ul{ class: dom_class(events_list), id: dom_id(events_list) }
+    = render partial: 'event', collection: events_list.structure_items.sorted_by_structure, layout: 'list_item',
+             cached: ->(event) { [event, event.structure_parts.collect(&:structure_partable)] }
+- else
+  = render Primer::BlankSlateComponent.new(title: t(:'.no_events'), icon: 'file')

--- a/config/initializers/themes/conferences_primer_theme.rb
+++ b/config/initializers/themes/conferences_primer_theme.rb
@@ -72,6 +72,10 @@
     name: 'sponsors',
     title: 'Sponsors',
     partable_type: 'Spina::Structure'
+  }, {
+    name: 'events_list',
+    title: 'Events',
+    partable_type: 'Spina::Structure'
   }]
 
   theme.layout_parts = [{
@@ -213,6 +217,30 @@
       title: 'Website',
       partable_type: 'Spina::Admin::Conferences::UrlPart'
     }]
+  }, {
+    name: 'events_list',
+    title: 'Events',
+    structure_parts: [{
+      name: 'name',
+      title: 'Name',
+      partable_type: 'Spina::Line'
+    }, {
+      name: 'start_time',
+      title: 'Time',
+      partable_type: 'Spina::Admin::Conferences::TimePart'
+    }, {
+      name: 'location',
+      title: 'Location',
+      partable_type: 'Spina::Line'
+    }, {
+      name: 'description',
+      title: 'Description',
+      partable_type: 'Spina::Text'
+    }, {
+      name: 'url',
+      title: 'Link',
+      partable_type: 'Spina::Admin::Conferences::UrlPart'
+    }]
   }]
 
   theme.view_templates = [{
@@ -234,6 +262,11 @@
     title: 'About',
     description: 'Contains information about the society',
     page_parts: %w[text constitution minutes documents partner_societies contact]
+  }, {
+    name: 'events',
+    title: 'Events',
+    description: 'Contains details of past and upcoming events',
+    page_parts: %w[text events_list]
   }, {
     name: 'show',
     title: 'Blank',

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -94,6 +94,9 @@ en:
         website: Website
         email: Email
         contact_buttons: Contact buttons
+      events_list:
+        upcoming: Upcoming events
+        past: Past events
       event:
         time_and_place: "%{place}, %{time}"
         time_tbc: Time TBC

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -94,6 +94,11 @@ en:
         website: Website
         email: Email
         contact_buttons: Contact buttons
+      event:
+        time_and_place: "%{place}, %{time}"
+        time_tbc: Time TBC
+        location_tbc: Location TBC
+        more_info: More information
 
     conferences:
       primer_theme:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -94,9 +94,12 @@ en:
         website: Website
         email: Email
         contact_buttons: Contact buttons
+      events:
+        no_events: No events.
       events_list:
         upcoming: Upcoming events
         past: Past events
+        no_events: No events.
       event:
         time_and_place: "%{place}, %{time}"
         time_tbc: Time TBC


### PR DESCRIPTION
Add an events page type with a single Spina::Structure. Events are displayed separated into past and upcoming events.