### PR TITLE
Add institution part to committee bios repeater

### DIFF
--- a/config/initializers/themes/conferences_primer_theme.rb
+++ b/config/initializers/themes/conferences_primer_theme.rb
@@ -75,7 +75,7 @@
     name: 'committee_bios',
     title: 'Committee bios',
     part_type: 'Spina::Parts::Repeater',
-    parts: %w[name role bio profile_picture]
+    parts: %w[name institution role bio profile_picture]
   }, {
     name: 'sponsors',
     title: 'Sponsors',

--- a/test/fixtures/spina/pages.yml
+++ b/test/fixtures/spina/pages.yml
@@ -315,6 +315,10 @@ committee:
                 title: Name
                 type: Spina::Parts::Line
                 content: Joe Bloggs
+              - name: institution
+                title: Institution
+                type: Spina::Parts::Line
+                content: University of California
               - name: role
                 title: Role
                 type: Spina::Parts::Line
@@ -350,6 +354,9 @@ committee:
             parts:
               - name: name
                 title: Name
+                type: Spina::Parts::Line
+              - name: institution
+                title: Institution
                 type: Spina::Parts::Line
               - name: role
                 title: Role
@@ -390,6 +397,10 @@ committee:
                 title: Name
                 type: Spina::Parts::Line
                 content: Joe Bloggs
+              - name: institution
+                title: Institution
+                type: Spina::Parts::Line
+                content: University of California
               - name: role
                 title: Role
                 type: Spina::Parts::Line
@@ -426,6 +437,9 @@ committee:
               - name: name
                 title: Name
                 type: Spina::Parts::Line
+              - name: institution
+                title: Institution
+                type: Spina::Parts::Line
               - name: role
                 title: Role
                 type: Spina::Parts::Line
@@ -446,31 +460,31 @@ committee:
 
 blank:
   name: blank
-  json_attributes:  
+  json_attributes:
 
 empty_homepage:
   name: homepage
   view_template: homepage
-  json_attributes:  
+  json_attributes:
 
 empty_information:
   name: information
   view_template: information
-  json_attributes:  
+  json_attributes:
 
 empty_about:
   name: about
   view_template: about
-  json_attributes:  
+  json_attributes:
 
 empty_committee:
   name: committee
   view_template: committee
-  json_attributes:  
+  json_attributes:
 
 empty_blank:
   name: blank
-  json_attributes:  
+  json_attributes:
 
 homepage_without_partables:
   name: homepage
@@ -564,14 +578,14 @@ page_with_ancestor:
   name: page_with_ancestor
   ancestry: <%= ActiveRecord::FixtureSet.identify(:blank) %>
   view_template: information
-  json_attributes:  
+  json_attributes:
 
 page_with_description:
   name: page_with_description
   view_template: blank
-  json_attributes:  
+  json_attributes:
 
 page_without_description:
   name: page_without_description
   view_template: blank
-  json_attributes:  
+  json_attributes:

--- a/test/integration/spina/conferences/primer_theme/pages_navigation_test.rb
+++ b/test/integration/spina/conferences/primer_theme/pages_navigation_test.rb
@@ -222,6 +222,8 @@ module Spina
                         else
                           assert_select 'h3', text: committee_bio.content(:name), count: committee_bio.content(:name).present? ? 1 : 0
                         end
+                        assert_select 'h4',
+                                      text: committee_bio.content(:institution), count: committee_bio.content(:institution).present? ? 1 : 0
                         assert_link committee_bio.content(:facebook_profile),
                                     text: 'Facebook', count: committee_bio.content(:facebook_profile).present? ? 1 : 0
                         assert_link committee_bio.content(:twitter_profile),


### PR DESCRIPTION
Re-add the institution part, which got lost in the migration to Spina-v2