### PR TITLE
Fix navigation caching

### DIFF
--- a/app/views/spina/application/_mobile_navigation_item.html.haml
+++ b/app/views/spina/application/_mobile_navigation_item.html.haml
@@ -1,13 +1,12 @@
-- cache [navigation_item, navigation_item.children] do
-  .Header-item.mr-0.border-top.border-white-fade-15.flex-column.flex-items-stretch
-    - if navigation_item.has_children?
-      %details.details-reset
-        %summary.Header-link.py-2
-          = navigation_item.menu_title
-          = render Primer::OcticonComponent.new('chevron-down')
-        %ul.list-style-none
-          - navigation_item.children.each do |child|
-            %li= link_to child.menu_title, child.materialized_path, class: %w[d-block py-2 pl-3 border-top border-white-fade color-text-white]
-    - elsif navigation_item.is_root?
-      = link_to navigation_item.menu_title, navigation_item.materialized_path,
-                class: %w[Header-link py-2]
+.Header-item.mr-0.border-top.border-white-fade-15.flex-column.flex-items-stretch
+  - if navigation_item.has_children?
+    %details.details-reset
+      %summary.Header-link.py-2
+        = navigation_item.menu_title
+        = render Primer::OcticonComponent.new('chevron-down')
+      %ul.list-style-none
+        - navigation_item.children.each do |child|
+          %li= link_to child.menu_title, child.materialized_path, class: %w[d-block py-2 pl-3 border-top border-white-fade color-text-white]
+  - elsif navigation_item.is_root?
+    = link_to navigation_item.menu_title, navigation_item.materialized_path,
+              class: %w[Header-link py-2]

--- a/app/views/spina/application/_mobile_navigation_item.html.haml
+++ b/app/views/spina/application/_mobile_navigation_item.html.haml
@@ -1,4 +1,4 @@
-- cache navigation_item do
+- cache [navigation_item, navigation_item.children] do
   .Header-item.mr-0.border-top.border-white-fade-15.flex-column.flex-items-stretch
     - if navigation_item.has_children?
       %details.details-reset

--- a/app/views/spina/application/_mobile_navigation_items.html.haml
+++ b/app/views/spina/application/_mobile_navigation_items.html.haml
@@ -1,3 +1,3 @@
 %nav.d-flex.flex-column.flex-self-stretch
-  = render partial: 'mobile_navigation_item', collection: main_navigation_items, cached: true, as: :navigation_item
+  = render partial: 'mobile_navigation_item', collection: main_navigation_items, as: :navigation_item
   .Header-item.mr-0.border-top.border-white-fade-15= link_to 'Conferences', frontend_conferences_path, class: %w[Header-link py-2 py-lg-0]

--- a/app/views/spina/application/_mobile_navigation_items.html.haml
+++ b/app/views/spina/application/_mobile_navigation_items.html.haml
@@ -1,3 +1,3 @@
 %nav.d-flex.flex-column.flex-self-stretch
-  = render partial: 'mobile_navigation_item', collection: main_navigation_items, as: :navigation_item
+  = render partial: 'mobile_navigation_item', collection: main_navigation_items, as: :navigation_item, cache: -> navigation_item { [navigation_item, navigation_item.children] }
   .Header-item.mr-0.border-top.border-white-fade-15= link_to 'Conferences', frontend_conferences_path, class: %w[Header-link py-2 py-lg-0]

--- a/app/views/spina/application/_navigation.html.haml
+++ b/app/views/spina/application/_navigation.html.haml
@@ -6,6 +6,6 @@
         = render Primer::OcticonComponent.new('three-bars', height: 24)
       .Header-item.Header-item--full.flex-column.width-full.flex-order-1.mr-0.mt-3
         = render partial: 'mobile_navigation_items'
-    = render partial: 'navigation_item', collection: main_navigation_items
+    = render partial: 'navigation_item', collection: main_navigation_items, cache: -> navigation_item { [navigation_item, navigation_item.children] }
     .Header-item.d-none.d-lg-flex= link_to 'Journal', frontend_issues_path, class: %w[Header-link]
     .Header-item.d-none.d-lg-flex= link_to 'Conferences', frontend_conferences_path, class: %w[Header-link]

--- a/app/views/spina/application/_navigation.html.haml
+++ b/app/views/spina/application/_navigation.html.haml
@@ -6,6 +6,6 @@
         = render Primer::OcticonComponent.new('three-bars', height: 24)
       .Header-item.Header-item--full.flex-column.width-full.flex-order-1.mr-0.mt-3
         = render partial: 'mobile_navigation_items'
-    = render partial: 'navigation_item', collection: main_navigation_items, cached: true
+    = render partial: 'navigation_item', collection: main_navigation_items
     .Header-item.d-none.d-lg-flex= link_to 'Journal', frontend_issues_path, class: %w[Header-link]
     .Header-item.d-none.d-lg-flex= link_to 'Conferences', frontend_conferences_path, class: %w[Header-link]

--- a/app/views/spina/application/_navigation_item.html.haml
+++ b/app/views/spina/application/_navigation_item.html.haml
@@ -1,12 +1,11 @@
-- cache [navigation_item, navigation_item.children] do
-  .Header-item.position-relative.d-none.d-lg-flex
-    - if navigation_item.has_children? && navigation_item.children.regular_pages.in_menu.live.sorted.any?
-      %details.details-reset.details-overlay
-        %summary.Header-link{ role: 'button', aria: { haspopup: 'menu' } }
-          = navigation_item.menu_title
-          = render Primer::OcticonComponent.new('chevron-down')
-        %ul.dropdown-menu.dropdown-menu-sw
-          - navigation_item.children.regular_pages.in_menu.live.sorted.each do |child|
-            %li= link_to child.menu_title, child.materialized_path, class: 'dropdown-item'
-    - elsif navigation_item.is_root?
-      = link_to navigation_item.menu_title, navigation_item.materialized_path, class: %w[Header-link]
+.Header-item.position-relative.d-none.d-lg-flex
+  - if navigation_item.has_children? && navigation_item.children.regular_pages.in_menu.live.sorted.any?
+    %details.details-reset.details-overlay
+      %summary.Header-link{ role: 'button', aria: { haspopup: 'menu' } }
+        = navigation_item.menu_title
+        = render Primer::OcticonComponent.new('chevron-down')
+      %ul.dropdown-menu.dropdown-menu-sw
+        - navigation_item.children.regular_pages.in_menu.live.sorted.each do |child|
+          %li= link_to child.menu_title, child.materialized_path, class: 'dropdown-item'
+  - elsif navigation_item.is_root?
+    = link_to navigation_item.menu_title, navigation_item.materialized_path, class: %w[Header-link]

--- a/app/views/spina/application/_navigation_item.html.haml
+++ b/app/views/spina/application/_navigation_item.html.haml
@@ -1,4 +1,4 @@
-- cache navigation_item do
+- cache [navigation_item, navigation_item.children] do
   .Header-item.position-relative.d-none.d-lg-flex
     - if navigation_item.has_children? && navigation_item.children.regular_pages.in_menu.live.sorted.any?
       %details.details-reset.details-overlay


### PR DESCRIPTION
Include navigation item children in cache key so that updating a child item updates the entire parent element.

I'm not sure why this doesn't work as is, since Spina::NavigationsController touches parents when children are updated. Hopefully this PR fixes the bug though.