### PR TITLE
Improve frontend for journal plugin

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ PATH
       rails (~> 6.0)
       spina (~> 2.0)
       spina-admin-conferences (~> 2.1.0)
-      spina-admin-journal (~> 0.4.1)
+      spina-admin-journal (~> 0.4.2)
 
 GEM
   remote: https://rubygems.org/
@@ -311,7 +311,7 @@ GEM
       spina (~> 2.0)
       stimulus-rails (~> 0.2.2)
       turbo-rails (~> 0.5.9)
-    spina-admin-journal (0.4.1)
+    spina-admin-journal (0.4.2)
       babel-transpiler (~> 0.7)
       rails (~> 6.1)
       rails-i18n (~> 6.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ PATH
       rails (~> 6.0)
       spina (~> 2.0)
       spina-admin-conferences (~> 2.1.0)
-      spina-admin-journal (~> 0.4.0)
+      spina-admin-journal (~> 0.4.1)
 
 GEM
   remote: https://rubygems.org/
@@ -311,7 +311,7 @@ GEM
       spina (~> 2.0)
       stimulus-rails (~> 0.2.2)
       turbo-rails (~> 0.5.9)
-    spina-admin-journal (0.4.0)
+    spina-admin-journal (0.4.1)
       babel-transpiler (~> 0.7)
       rails (~> 6.1)
       rails-i18n (~> 6.0)

--- a/app/controllers/spina/conferences/primer_theme/journal/issues_controller.rb
+++ b/app/controllers/spina/conferences/primer_theme/journal/issues_controller.rb
@@ -13,7 +13,7 @@ module Spina
           def index
             # having multiple journals is not currently allowed anyway
             @issues = Admin::Journal::Issue.sorted_desc
-            @latest_issue = @issues.find { |issue| issue.date <= Time.zone.today }
+            @latest_issue = @issues.find_by 'date <= ?', Time.zone.today
           end
 
           def show

--- a/app/controllers/spina/conferences/primer_theme/journal/issues_controller.rb
+++ b/app/controllers/spina/conferences/primer_theme/journal/issues_controller.rb
@@ -13,6 +13,7 @@ module Spina
           def index
             # having multiple journals is not currently allowed anyway
             @issues = Admin::Journal::Issue.sorted_desc
+            @latest_issue = @issues.find { |issue| issue.date <= Time.zone.today }
           end
 
           def show

--- a/app/views/spina/conferences/primer_theme/journal/articles/show.html.haml
+++ b/app/views/spina/conferences/primer_theme/journal/articles/show.html.haml
@@ -1,50 +1,51 @@
-= render(Primer::HeadingComponent.new) { @article.title }
+- cache [@article, @article.authorships, @article.affiliations, @article.content(:abstract), @article.issue, @article.issue.volume, @article.issue.content(:cover_img)] do
+  = render(Primer::HeadingComponent.new) { @article.title }
 
-= render(Primer::FlexComponent.new(direction: [:column, nil, :row, nil])) do
-  = render(Primer::FlexItemComponent.new(flex_auto: true, mr: [nil, nil, 4, nil])) do
-    %ul.list-style-none.d-flex.flex-column.flex-sm-row.my-2
-      - @article.affiliations.each do |affiliation|
-        = render(Primer::FlexComponent.new(tag: :li, mr: 4, align_items: :center)) do
-          = render(Primer::FlexItemComponent.new(mr: 2)) do
-            = render(Primer::OcticonComponent.new('person'))
-          = render(Primer::FlexComponent.new(tag: :address, direction: :column)) do
-            = render(Primer::TextComponent.new(tag: :div, font_weight: :bold)) { affiliation.name }
-            = render(Primer::TextComponent.new(tag: :div, color: :text_secondary)) { affiliation.institution.name }
+  = render(Primer::FlexComponent.new(direction: [:column, nil, :row, nil])) do
+    = render(Primer::FlexItemComponent.new(flex_auto: true, mr: [nil, nil, 4, nil])) do
+      %ul.list-style-none.d-flex.flex-column.flex-sm-row.my-2
+        - @article.affiliations.each do |affiliation|
+          = render(Primer::FlexComponent.new(tag: :li, mr: 4, align_items: :center)) do
+            = render(Primer::FlexItemComponent.new(mr: 2)) do
+              = render(Primer::OcticonComponent.new('person'))
+            = render(Primer::FlexComponent.new(tag: :address, direction: :column)) do
+              = render(Primer::TextComponent.new(tag: :div, font_weight: :bold)) { affiliation.name }
+              = render(Primer::TextComponent.new(tag: :div, color: :text_secondary)) { affiliation.institution.name }
 
-    - if @article.has_content?(:abstract)
-      = render(Primer::HeadingComponent.new(tag: :h2, mt: 4, font_size: 3)) { t '.abstract' }
-      = render(Primer::MarkdownComponent.new) { @article.content.html(:abstract) }
+      - if @article.has_content?(:abstract)
+        = render(Primer::HeadingComponent.new(tag: :h2, mt: 4, font_size: 3)) { t '.abstract' }
+        = render(Primer::MarkdownComponent.new) { @article.content.html(:abstract) }
 
-  = render(Primer::BorderBoxComponent.new(ml: [nil, nil, 4, nil])) do |sidebar|
-    - sidebar.body do
-      - if @article.issue.has_content?(:cover_img)
-        = render partial: 'spina/journal/primer_theme/issues/issue_cover', locals: { issue: @article.issue, cover_img: @article.issue.content(:cover_img), size: [200, 400] }
-      = render(Primer::BorderBoxComponent.new) do |component|
-        - if @article.has_content?(:attachment)
+    = render(Primer::BorderBoxComponent.new(ml: [nil, nil, 4, nil], style: 'min-width: 20vw')) do |sidebar|
+      - sidebar.body do
+        - if @article.issue.has_content?(:cover_img)
+          = render partial: 'spina/conferences/primer_theme/journal/issues/issue_cover', locals: { issue: @article.issue, cover_img: @article.issue.content(:cover_img), size: [200, 400] }
+        = render(Primer::BorderBoxComponent.new) do |component|
+          - if @article.has_content?(:attachment)
+            - component.row do
+              = render(Primer::ButtonComponent.new(tag: :a, href: main_app.url_for(@article.content(:attachment)), download: '', scheme: :primary)) do
+                = render Primer::OcticonComponent.new('download')
+                = t '.download'
           - component.row do
-            = render(Primer::ButtonComponent.new(tag: :a, href: main_app.url_for(@article.content(:attachment)), download: '', scheme: :primary)) do
-              = render Primer::OcticonComponent.new('download')
-              = t '.download'
-        - component.row do
-          = render(Primer::HeadingComponent.new(tag: :h2, font_size: 4, color: :text_secondary)) { t '.published' }
-          = render(Primer::TextComponent.new) do
-            = time_tag @article.issue.date, format: :long
-        - component.row do
-          = render(Primer::HeadingComponent.new(tag: :h2, font_size: 4, color: :text_secondary)) { t '.issue' }
-          = render(Primer::TextComponent.new) do
-            = link_to t('spina.journal.primer_theme.volume_issue',
-                        volume_number: @article.issue.volume.number,
-                        issue_number: @article.issue.number), frontend_issue_path(@article.issue)
-        - unless @article.doi.blank?
-          = component.row do
-            = render(Primer::HeadingComponent.new(tag: :h2, font_size: 4, color: :text_secondary)) { t '.doi' }
-            = render(Primer::TextComponent.new(tag: :div, color: :text_secondary, mt: 1)) do
-              = link_to nil, @article.doi
-        - unless @article.url.blank?
-          = component.row do
-            = render(Primer::HeadingComponent.new(tag: :h2, font_size: 4, color: :text_secondary)) { t '.url' }
-            = render(Primer::TextComponent.new(tag: :div, color: :text_secondary, mt: 1)) do
-              = link_to nil, @article.url
-        - if @article.draft?
-          = component.row do
-            = render(Primer::TextComponent.new(tag: :div, color: :text_danger, font_weight: :bold)) { t '.draft' }
+            = render(Primer::HeadingComponent.new(tag: :h2, font_size: 4, color: :text_secondary)) { t '.published' }
+            = render(Primer::TextComponent.new) do
+              = time_tag @article.issue.date, format: :long
+          - component.row do
+            = render(Primer::HeadingComponent.new(tag: :h2, font_size: 4, color: :text_secondary)) { t '.issue' }
+            = render(Primer::TextComponent.new) do
+              = link_to t('spina.conferences.primer_theme.journal.volume_issue',
+                          volume_number: @article.issue.volume.number,
+                          issue_number: @article.issue.number), frontend_issue_path(@article.issue)
+          - unless @article.doi.blank?
+            - component.row do
+              = render(Primer::HeadingComponent.new(tag: :h2, font_size: 4, color: :text_secondary)) { t '.doi' }
+              = render(Primer::TextComponent.new(tag: :div, color: :text_secondary, mt: 1)) do
+                = link_to nil, @article.doi
+          - unless @article.url.blank?
+            - component.row do
+              = render(Primer::HeadingComponent.new(tag: :h2, font_size: 4, color: :text_secondary)) { t '.url' }
+              = render(Primer::TextComponent.new(tag: :div, color: :text_secondary, mt: 1)) do
+                = link_to nil, @article.url
+          - if @article.draft?
+            - component.row do
+              = render(Primer::TextComponent.new(tag: :div, color: :text_danger, font_weight: :bold)) { t '.draft' }

--- a/app/views/spina/conferences/primer_theme/journal/articles/show.html.haml
+++ b/app/views/spina/conferences/primer_theme/journal/articles/show.html.haml
@@ -46,6 +46,15 @@
               = render(Primer::HeadingComponent.new(tag: :h2, font_size: 4, color: :text_secondary)) { t '.url' }
               = render(Primer::TextComponent.new(tag: :div, color: :text_secondary, mt: 1)) do
                 = link_to nil, @article.url
+          - component.row do
+            -# TODO: allow user to select licence
+            = render(Primer::FlexComponent.new(direction: :column)) do
+              = render(Primer::TextComponent.new(mb: 2)) do
+                Copyright #{@article.issue.date.year} #{@article.affiliations.collect(&:name).to_sentence}
+              %a{ rel: 'licence', href: 'https://creativecommons.org/licenses/by/4.0/' }
+                %img{ alt: 'Creative Commons Attribution 4.0 International Licence', src: '//i.creativecommons.org/l/by/4.0/88x31.png' }
+            = render(Primer::TextComponent.new(mt: 1)) { t '.cc_by_licence_html' }
+
           - if @article.draft?
             - component.row do
               = render(Primer::TextComponent.new(tag: :div, color: :text_danger, font_weight: :bold)) { t '.draft' }

--- a/app/views/spina/conferences/primer_theme/journal/issues/_issue.html.haml
+++ b/app/views/spina/conferences/primer_theme/journal/issues/_issue.html.haml
@@ -3,12 +3,12 @@
     = render(Primer::FlexItemComponent.new(mr: 4)) do
       = render partial: 'issue_cover', locals: { issue: issue, cover_img: issue.content(:cover_img), size: [150, 300] }
   = render(Primer::FlexItemComponent.new(flex_auto: true)) do
-    = render(Primer::HeadingComponent.new(tag: :h2, mb: 1)) do
+    = render(Primer::HeadingComponent.new(tag: :h3, mb: 1)) do
       = link_to t('spina.conferences.primer_theme.journal.volume_issue',
                   volume_number: issue.volume.number,
                   issue_number: issue.number), frontend_issue_path(issue)
     - unless issue.title.blank?
-      = render(Primer::HeadingComponent.new(tag: :h3, color: :text_secondary, mb: 1)) do
+      = render(Primer::HeadingComponent.new(tag: :h4, color: :text_secondary, mb: 1)) do
         = issue.title
     = render(Primer::TextComponent.new(tag: :div, color: :text_secondary, font_weight: :bold)) do
       = time_tag issue.date, format: :long

--- a/app/views/spina/conferences/primer_theme/journal/issues/_issue_cover.html.haml
+++ b/app/views/spina/conferences/primer_theme/journal/issues/_issue_cover.html.haml
@@ -1,3 +1,4 @@
+-# locals: issue cover_img size[2]
 - cache cover_img do
   = image_tag main_app.url_for(cover_img.variant(resize_to_limit: size)),
               srcset: srcset(cover_img, variant: { resize_to_limit: size }),

--- a/app/views/spina/conferences/primer_theme/journal/issues/_issue_cover.html.haml
+++ b/app/views/spina/conferences/primer_theme/journal/issues/_issue_cover.html.haml
@@ -1,4 +1,3 @@
--# locals: issue cover_img size[2]
 - cache cover_img do
   = image_tag main_app.url_for(cover_img.variant(resize_to_limit: size)),
               srcset: srcset(cover_img, variant: { resize_to_limit: size }),

--- a/app/views/spina/conferences/primer_theme/journal/issues/index.html.haml
+++ b/app/views/spina/conferences/primer_theme/journal/issues/index.html.haml
@@ -1,10 +1,19 @@
-= render(Primer::HeadingComponent.new) { @journal.name }
-
-- if @journal.content(:description).present?
-  = render(Primer::MarkdownComponent.new(mt: 4)) { @journal.content.html(:description) }
+= render(Primer::FlexComponent.new(direction: [:column, nil, :row, nil])) do
+  = render(Primer::FlexComponent.new(direction: :column, flex: :auto)) do
+    = render(Primer::HeadingComponent.new) { @journal.name }
+    - if @journal.has_content? :description
+      = render(Primer::MarkdownComponent.new(my: 4)) { @journal.content.html(:description) }
+  - if @journal.has_content? :logo
+    = render(Primer::FlexItemComponent.new(mb: 4)) do
+      - cache @journal.content(:logo) do
+        = image_tag main_app.url_for(@journal.content(:logo).variant(resize_to_limit: [300, 150])),
+                    srcset: srcset(@journal.content(:logo), variant: { resize_to_limit: [300, 150] }),
+                    alt_description: t('.logo'),
+                    draggable: false,
+                    class: 'p-1'
 
 %div#journal-issues-list.border-top
   - if @issues.any?
-    %ul= render partial: 'issue', collection: @issues, layout: 'list_item'
+    %ul= render partial: 'issue', collection: @issues, layout: 'list_item', cached: true
   - else
     = render Primer::BlankslateComponent.new(title: t(:'.no_issues'), icon: 'mortar-board')

--- a/app/views/spina/conferences/primer_theme/journal/issues/index.html.haml
+++ b/app/views/spina/conferences/primer_theme/journal/issues/index.html.haml
@@ -3,7 +3,7 @@
     = render(Primer::HeadingComponent.new) { @journal.name }
     - if @journal.has_content? :description
       = render(Primer::MarkdownComponent.new(my: 4)) { @journal.content.html(:description) }
-  = render(Primer::BorderBoxComponent.new(ml: [nil, nil, 4, nil])) do |sidebar|
+  = render(Primer::BorderBoxComponent.new(ml: [nil, nil, 4, nil], style: 'min-width: 15vw;')) do |sidebar|
     - if @journal.has_content? :logo
       - sidebar.header(bg: :primary) do
         = render(Primer::FlexItemComponent.new(mb: 4)) do

--- a/app/views/spina/conferences/primer_theme/journal/issues/index.html.haml
+++ b/app/views/spina/conferences/primer_theme/journal/issues/index.html.haml
@@ -3,16 +3,27 @@
     = render(Primer::HeadingComponent.new) { @journal.name }
     - if @journal.has_content? :description
       = render(Primer::MarkdownComponent.new(my: 4)) { @journal.content.html(:description) }
-  - if @journal.has_content? :logo
-    = render(Primer::FlexItemComponent.new(mb: 4)) do
-      - cache @journal.content(:logo) do
-        = image_tag main_app.url_for(@journal.content(:logo).variant(resize_to_limit: [300, 150])),
-                    srcset: srcset(@journal.content(:logo), variant: { resize_to_limit: [300, 150] }),
-                    alt_description: t('.logo'),
-                    draggable: false,
-                    class: 'p-1'
+  = render(Primer::BorderBoxComponent.new(ml: [nil, nil, 4, nil])) do |sidebar|
+    - if @journal.has_content? :logo
+      - sidebar.header(bg: :primary) do
+        = render(Primer::FlexItemComponent.new(mb: 4)) do
+          - cache @journal.content(:logo) do
+            = image_tag main_app.url_for(@journal.content(:logo).variant(resize_to_limit: [300, 150])),
+                        srcset: srcset(@journal.content(:logo), variant: { resize_to_limit: [300, 150] }),
+                        alt_description: t('.logo'),
+                        draggable: false,
+                        class: 'p-1'
+    - unless @latest_issue.nil?
+      - sidebar.row do
+        = render(Primer::HeadingComponent.new(tag: :h2, font_size: 3)) do
+          = link_to t('.latest_issue', volume_number: @latest_issue.volume.number, issue_number: @latest_issue.number), frontend_issue_path(@latest_issue)
+    - if @latest_issue.has_content?(:cover_img)
+      - sidebar.row do
+        = link_to(frontend_issue_path(@latest_issue)) do
+          = render partial: 'issue_cover', locals: { issue: @latest_issue, cover_img: @latest_issue.content(:cover_img), size: [150, 300] }
 
-%div#journal-issues-list.border-top
+#journal-issues-list
+  = render(Primer::HeadingComponent.new(tag: :h2, mt: 3)) { t '.all_issues' }
   - if @issues.any?
     %ul= render partial: 'issue', collection: @issues, layout: 'list_item', cached: true
   - else

--- a/app/views/spina/conferences/primer_theme/journal/issues/show.html.haml
+++ b/app/views/spina/conferences/primer_theme/journal/issues/show.html.haml
@@ -15,6 +15,11 @@
     = render(Primer::MarkdownComponent.new(my: 4)) do
       = @issue.content.html(:description)
 
+  - if @issue.has_content?(:attachment)
+    = render(Primer::ButtonComponent.new(tag: :a, scheme: :primary, href: main_app.url_for(@issue.content(:attachment)), my: 2, download: '')) do
+      = render Primer::OcticonComponent.new('download')
+      = t '.download'
+
   %div#journal-articles-list.border-top
     - if @articles.any?
       %ul= render partial: 'article', collection: @articles.sorted_asc, layout: 'list_item', cached: true

--- a/app/views/spina/conferences/primer_theme/journal/issues/show.html.haml
+++ b/app/views/spina/conferences/primer_theme/journal/issues/show.html.haml
@@ -1,18 +1,22 @@
-= render(Primer::HeadingComponent.new) do
-  = t('spina.conferences.primer_theme.journal.volume_issue', volume_number: @issue.volume.number, issue_number: @issue.number)
+- cache [@issue, @issue.volume, @issue.articles, @issue.content(:cover_img), @issue.content(:description)] do
+  - cache [@issue, @issue.volume] do
+    = render(Primer::HeadingComponent.new) do
+      = t('spina.conferences.primer_theme.journal.volume_issue',
+          volume_number: @issue.volume.number,
+          issue_number: @issue.number)
 
-- unless @issue.title.blank?
-  = render(Primer::HeadingComponent.new(tag: :h2, color: :text_secondary, mb: 2)) { @issue.title }
+    - unless @issue.title.blank?
+      = render(Primer::HeadingComponent.new(tag: :h2, color: :text_secondary, mb: 2)) { @issue.title }
 
-- if @issue.has_content?(:cover_img)
-  = render partial: 'issue_cover', locals: { issue: @issue, cover_img: @issue.content(:cover_img), size: [300, 600] }
+  - if @issue.has_content?(:cover_img)
+    = render partial: 'issue_cover', locals: { issue: @issue, cover_img: @issue.content(:cover_img), size: [300, 600] }
 
-- if @issue.has_content?(:description)
-  = render(Primer::MarkdownComponent.new(my: 4)) do
-    = @issue.content.html(:description)
+  - if @issue.has_content?(:description)
+    = render(Primer::MarkdownComponent.new(my: 4)) do
+      = @issue.content.html(:description)
 
-%div#journal-articles-list.border-top
-  - if @articles.any?
-    %ul= render partial: 'article', collection: @articles.sorted_asc, layout: 'list_item'
-  - else
-    = render Primer::BlankslateComponent.new(title: t(:'.no_articles'), icon: 'mortar-board')
+  %div#journal-articles-list.border-top
+    - if @articles.any?
+      %ul= render partial: 'article', collection: @articles.sorted_asc, layout: 'list_item', cached: true
+    - else
+      = render Primer::BlankslateComponent.new(title: t(:'.no_articles'), icon: 'mortar-board')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -167,6 +167,8 @@ en:
             index:
               no_issues: This journal has no issues.
               logo: Journal logo
+              all_issues: All Issues
+              latest_issue: "Latest Issue (Vol. %{volume_number} Issue %{issue_number})"
             show:
               no_articles: This issue has no articles.
             article:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -171,6 +171,7 @@ en:
               latest_issue: "Latest Issue (Vol. %{volume_number} Issue %{issue_number})"
             show:
               no_articles: This issue has no articles.
+              download: Full Issue PDF
             article:
               download: PDF
           articles:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -180,6 +180,7 @@ en:
               published: Published
               issue: Issue
               draft: THIS ARTICLE IS A DRAFT
+              cc_by_licence_html: This work is licensed under a <a rel="license" href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.
 
   languages:
     en-GB: British English

--- a/spina-conferences-primer_theme.gemspec
+++ b/spina-conferences-primer_theme.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rails', '~> 6.0'
   spec.add_dependency 'spina', '~> 2.0'
   spec.add_dependency 'spina-admin-conferences', '~> 2.1.0'
-  spec.add_dependency 'spina-admin-journal', '~> 0.4.0'
+  spec.add_dependency 'spina-admin-journal', '~> 0.4.1'
 
   spec.add_development_dependency 'capybara', '~> 3.33'
   spec.add_development_dependency 'dotenv-rails', '~> 2.7'

--- a/spina-conferences-primer_theme.gemspec
+++ b/spina-conferences-primer_theme.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rails', '~> 6.0'
   spec.add_dependency 'spina', '~> 2.0'
   spec.add_dependency 'spina-admin-conferences', '~> 2.1.0'
-  spec.add_dependency 'spina-admin-journal', '~> 0.4.1'
+  spec.add_dependency 'spina-admin-journal', '~> 0.4.2'
 
   spec.add_development_dependency 'capybara', '~> 3.33'
   spec.add_development_dependency 'dotenv-rails', '~> 2.7'

--- a/test/integration/spina/conferences/primer_theme/journal/issues_navigation_test.rb
+++ b/test/integration/spina/conferences/primer_theme/journal/issues_navigation_test.rb
@@ -13,14 +13,16 @@ module Spina
             get frontend_issues_path
             assert_response :success
             assert_select 'main' do
-              assert_select 'ul' do
-                Spina::Admin::Journal::Issue.sorted_desc.each do |issue|
-                  assert_select 'li' do
-                    assert_select 'h2', text: I18n.t('spina.conferences.primer_theme.journal.volume_issue',
-                                                    volume_number: issue.volume.number,
-                                                    issue_number: issue.number)
-                    assert_select('h3', text: issue.title) if issue.title.present?
-                    assert_select 'time', text: I18n.l(issue.date, format: :long)
+              assert_select 'div#journal-issues-list' do
+                assert_select 'ul' do
+                  Spina::Admin::Journal::Issue.sorted_desc.each do |issue|
+                    assert_select 'li' do
+                      assert_select 'h3', text: I18n.t('spina.conferences.primer_theme.journal.volume_issue',
+                                                      volume_number: issue.volume.number,
+                                                      issue_number: issue.number)
+                      assert_select('h4', text: issue.title) if issue.title.present?
+                      assert_select 'time', text: I18n.l(issue.date, format: :long)
+                    end
                   end
                 end
               end


### PR DESCRIPTION
This PR re-adds some code which I mistakenly deleted before merging the original `refactor` branch. It also:
* Displays licence information for articles (currently hardcoded)
* Adds a sidebar to the issues index
* Updates `spina-admin-journal` to 0.4.2
* Adds a download button for an entire issue